### PR TITLE
Fix misused `Jquery` constant.

### DIFF
--- a/lib/mootools/rails/engine.rb
+++ b/lib/mootools/rails/engine.rb
@@ -1,4 +1,4 @@
-module Jquery
+module Mootools
   module Rails
     Engine = Class.new(::Rails::Engine)
   end


### PR DESCRIPTION
Even though the gem was working normally, this produces
an incompatibility with the `jquery-rails` gem (reported
at rails/jquery-rails#145).
